### PR TITLE
DoubleClickOpenFile

### DIFF
--- a/Log Files Utility/Log Files Utility/Form1.Designer.cs
+++ b/Log Files Utility/Log Files Utility/Form1.Designer.cs
@@ -243,6 +243,7 @@
             this.occurancesTree.Size = new System.Drawing.Size(235, 222);
             this.occurancesTree.TabIndex = 8;
             this.occurancesTree.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.occurancesTree_NodeMouseClick);
+            this.occurancesTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.occurancesTree_NodeMouseDoubleClick);
             // 
             // searchLogsButton
             // 

--- a/Log Files Utility/Log Files Utility/Form1.cs
+++ b/Log Files Utility/Log Files Utility/Form1.cs
@@ -244,15 +244,16 @@ namespace Log_Files_Utility
             Console.WriteLine("searchTermTextBox_KeyUp. Key pressed: " + e.KeyCode.ToString());
             if (e.KeyCode == Keys.Enter && searchTermTextBox.TextLength > 0)
             {
-                searchLogsButton.Enabled = true;
-            }
-            else if (searchTermTextBox.TextLength == 0)
-            {
-                searchLogsButton.Enabled = false;
+                startSearchButtonClicked();
             }
         }
 
         private void searchLogsButton_Click(object sender, EventArgs e)
+        {
+            startSearchButtonClicked();
+        }
+
+        private void startSearchButtonClicked()
         {
             searchLogsButton.Enabled = false;
             searchTermTextBox.Enabled = false;
@@ -326,6 +327,20 @@ namespace Log_Files_Utility
         }
 
         private void openFileButton_Click(object sender, EventArgs e)
+        {
+            openFile();
+        }
+
+        private void occurancesTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        {
+            TreeNode n = occurancesTree.SelectedNode;
+            if (n.Level == 1)
+            {
+                openFile();
+            }
+        }
+
+        private void openFile()
         {
             string fileName = "";
             string lineNumber = "";


### PR DESCRIPTION
Updated so that double clicking on child Nodes (with line numbers) will open up the file the same as if clicking the Open File button. This doesn't include the parent nodes (file name and relative folder). Here, it will expand the node as before.

Also altered search Term text box so that pressing enter will start a search so that clicking Search isn't necessary.